### PR TITLE
Center xlabels when having verticalLabelRotation!=0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@Paindrainer/pd-react-native-chart-kit",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "type": "module",
   "description": "PD statistics and text generation.",
   "main": "src/index.ts",

--- a/src/AbstractChart.tsx
+++ b/src/AbstractChart.tsx
@@ -301,7 +301,7 @@ class AbstractChart<
           key={Math.random()}
           x={x}
           y={y}
-          textAnchor={verticalLabelRotation === 0 ? "middle" : "start"}
+          textAnchor={verticalLabelRotation === 0 ? "middle" : "middle"}
           {...this.getPropsForLabels()}
           {...this.getPropsForVerticalLabels()}
         >


### PR DESCRIPTION
At the moment, all xlabels shift to the right when verticalLabelRotation != 0, looks better to center them.